### PR TITLE
[scaled_grouped_mm] add support for out argument

### DIFF
--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -541,7 +541,8 @@ _scaled_grouped_mm_cuda_v2(
           const std::optional<Tensor>& bias,
           const std::optional<c10::ScalarType> out_dtype,
           IntArrayRef contraction_dim,
-          bool use_fast_accum) {
+          bool use_fast_accum,
+          const std::optional<Tensor>& out) {
   bool allowed_device = _scaled_mm_allowed_device(/*sm90_only*/true, /*sm100_only*/true);
   TORCH_CHECK_VALUE(allowed_device, "torch._scaled_grouped_mm is only supported on CUDA devices with compute capability = [9.0, 10.0], or ROCm MI300+");
 
@@ -551,6 +552,7 @@ _scaled_grouped_mm_cuda_v2(
   TORCH_CHECK_VALUE(mat_b.dim() == 2 || mat_b.dim() == 3, "mat_b has to be 2 or 3d");
   const bool a_is_2d = mat_a.dim() == 2;
   const bool b_is_2d = mat_b.dim() == 2;
+  const bool b_is_3d = mat_b.dim() == 3;
 
   // NOTE(slayton): For sub-1B formats want contraction_dim argument?
   if (!a_is_2d || !b_is_2d) {
@@ -591,7 +593,25 @@ _scaled_grouped_mm_cuda_v2(
   const auto out_dtype_ = out_dtype.value_or(kBFloat16);
   TORCH_CHECK_VALUE(out_dtype_ == kBFloat16, "Only bf16 high precision output types are supported for grouped gemm");
 
-  Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
+  Tensor output;
+  if (out.has_value()) {
+    output = out.value();
+    TORCH_CHECK_VALUE(output.dim() == 2 || output.dim() == 3, "Output tensor has to be 2 or 3d");
+    if (a_is_2d && b_is_2d) {
+      TORCH_CHECK_VALUE(output.dim() == 3, "Output tensor has to be 3d when both inputs are 2d");
+      TORCH_CHECK_VALUE(output.size(0) == offs->size(0), "out.shape[0] must match number of groups (offs.shape[0])");
+      TORCH_CHECK_VALUE(output.size(1) == mat_a.size(0), "out.shape[1] must match mat_a.shape[0]");
+      TORCH_CHECK_VALUE(output.size(2) == mat_b.size(1), "out.shape[2] must match mat_b.shape[1]");
+    } else if (a_is_2d && b_is_3d) {
+      TORCH_CHECK_VALUE(output.dim() == 2, "Output tensor has to be 2d when mat_a is 2d and mat_b is 3d");
+      TORCH_CHECK_VALUE(output.size(0) == mat_a.size(0), "out.shape[0] must match mat_a.shape[0]");
+      TORCH_CHECK_VALUE(output.size(1) == mat_b.size(2), "out.shape[1] must match mat_b.shape[2]");
+    } else {
+      TORCH_CHECK_NOT_IMPLEMENTED(false, "Only 2d-2d and 2d-3d input combinations are supported currently");
+    }
+  } else {
+    output = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
+  }
 
   // Conversion of implicitly-defined enums to explicit
   auto scale_recipe_a_enum = convert_int_to_enum<ScalingType>(scale_recipe_a);
@@ -633,7 +653,7 @@ _scaled_grouped_mm_cuda_v2(
           offs,
           bias,
           use_fast_accum,
-          out);
+          output);
     }
     case ScaledGemmImplementation::MXFP8_MXFP8: {
       // scale shape checks
@@ -649,7 +669,7 @@ _scaled_grouped_mm_cuda_v2(
           scale_b[0],
           swizzle_b_enum[0],
           offs.value(),
-          out);
+          output);
     }
     case ScaledGemmImplementation::MXFP4_MXFP4: {
       // scale shape checks
@@ -664,7 +684,7 @@ _scaled_grouped_mm_cuda_v2(
           std::nullopt, /* global-scale B */
           offs.value(),
           std::nullopt, /* bias */
-          out);
+          output);
     }
     case ScaledGemmImplementation::NVFP4_NVFP4: {
       // scale shape checks
@@ -679,7 +699,7 @@ _scaled_grouped_mm_cuda_v2(
           scale_b[1], /* global-scale B */
           offs.value(),
           std::nullopt, /* bias */
-          out);
+          output);
     }
     default:
       TORCH_CHECK_NOT_IMPLEMENTED(false,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7405,7 +7405,7 @@
     CUDA: _scaled_grouped_mm_cuda
   tags: needs_exact_strides
 
-- func: _scaled_grouped_mm_v2(Tensor self, Tensor mat2, Tensor[] scale_a, int[] recipe_a, int[] swizzle_a, Tensor[] scale_b, int[] recipe_b, int[] swizzle_b, Tensor? offs=None, Tensor? bias=None, ScalarType? out_dtype=None, int[] contraction_dim=[], bool use_fast_accum=False) -> Tensor
+- func: _scaled_grouped_mm_v2(Tensor self, Tensor mat2, Tensor[] scale_a, int[] recipe_a, int[] swizzle_a, Tensor[] scale_b, int[] recipe_b, int[] swizzle_b, Tensor? offs=None, Tensor? bias=None, ScalarType? out_dtype=None, int[] contraction_dim=[], bool use_fast_accum=False, Tensor? out=None) -> Tensor
   variants: function
   dispatch:
     CUDA: _scaled_grouped_mm_cuda_v2

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -267,6 +267,7 @@ def scaled_grouped_mm_wrap(
     offs=None,
     bias=None,
     wrap_v2=True,
+    out=None,
 ):
     if not wrap_v2:
         return torch._scaled_grouped_mm(
@@ -291,7 +292,9 @@ def scaled_grouped_mm_wrap(
             offs=offs,
             bias=bias,
             output_dtype=out_dtype,
-            use_fast_accum=use_fast_accum)
+            use_fast_accum=use_fast_accum,
+            out=out,
+        )
 
 
 
@@ -953,6 +956,76 @@ class TestFP8Matmul(TestCase):
 
         # Assert outputs are close.
         torch.testing.assert_close(y_lp, y_bf16, atol=8.0e-2, rtol=8.0e-2)
+
+
+    @onlyOn(["cuda"])
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM, mxfp8_grouped_mm_skip_msg)
+    def test_mxfp8_2d_2d_grouped_mm_out_argument(self, device) -> None:
+        if not _device_supports_scaled_mm_fp8(device):
+            raise unittest.SkipTest(f8_msg)
+        size = (256, 256)
+        x = torch.full(size, .5, device=device, dtype=e4m3_type)
+        y = torch.full(size, .5, device=device, dtype=e4m3_type).t()
+        offs = torch.tensor([128, 256], device=device, dtype=torch.int32)
+
+        prealloc_out = torch.empty((2, 256, 256), device=device, dtype=torch.bfloat16)
+        scale_x = torch.full((256, 8), 1.0, dtype=torch.float8_e8m0fnu, device=device)
+        scale_y = torch.full((256, 8), 1.0, dtype=torch.float8_e8m0fnu, device=device)
+
+        # only supported on v2 api
+        returned_out = scaled_grouped_mm_wrap(
+            x,
+            y,
+            scale_a=scale_x,
+            scale_b=scale_y,
+            scale_recipe_a=ScalingType.BlockWise1x32,
+            scale_recipe_b=ScalingType.BlockWise1x32,
+            swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+            swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+            offs=offs,
+            out=prealloc_out,
+            wrap_v2=True
+        )
+
+        if returned_out.data_ptr() != prealloc_out.data_ptr():
+            raise AssertionError("returned_out and prealloc_out must have the same data pointers")
+
+    @onlyOn(["cuda"])
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM, mxfp8_grouped_mm_skip_msg)
+    def test_mxfp8_2d_3d_grouped_mm_out_argument(self, device) -> None:
+        if not _device_supports_scaled_mm_fp8(device):
+            raise unittest.SkipTest(f8_msg)
+
+        G, M, N, K = 2, 256, 128, 128
+
+        x = torch.full((M, K), .5, device=device, dtype=e4m3_type)
+        w = torch.full((G, N, K), .5, device=device, dtype=e4m3_type)
+        offs = torch.tensor([M // G, M], device=device, dtype=torch.int32)
+
+        prealloc_out = torch.empty((M, N), device=device, dtype=torch.bfloat16)
+
+        # scales for mxfp8
+        scale_x = torch.full((M, K // 32), 1.0, dtype=torch.float8_e8m0fnu, device=device)
+        scale_y = torch.full((G, N * K // 32), 1.0, dtype=torch.float8_e8m0fnu, device=device)
+
+        # only supported on v2 api
+        returned_out = scaled_grouped_mm_wrap(
+            x,
+            w.transpose(-2, -1),
+            scale_a=scale_x,
+            scale_b=scale_y,
+            scale_recipe_a=ScalingType.BlockWise1x32,
+            scale_recipe_b=ScalingType.BlockWise1x32,
+            swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+            swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+            offs=offs,
+            out=prealloc_out,
+            wrap_v2=True
+        )
+
+        if returned_out.data_ptr() != prealloc_out.data_ptr():
+            raise AssertionError("returned_out and prealloc_out must have the same data pointers")
+
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @parametrize("base_dtype", [torch.float16, torch.bfloat16, torch.float32])

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6880,6 +6880,7 @@ def scaled_grouped_mm(
     output_dtype: torch.dtype | None = torch.bfloat16,
     contraction_dim: list[int] | tuple[int, ...] = (),
     use_fast_accum: bool = False,
+    out: Tensor | None = None,
 ) -> Tensor:
     r"""
     scaled_grouped_mm(mat_a, mat_b, scale_a, scale_recipe_a, scale_b, scale_recipe_b, swizzle_a, swizzle_b, bias, offs,
@@ -6900,6 +6901,7 @@ def scaled_grouped_mm(
         output_dtype: dtype used for the output tensor
         contraction_dim: describe which dimensions are :math:`K` in the matmul.
         use_fast_accum: enable/disable tensor-core fast accumulation (Hopper-GPUs only)
+        out: optional output tensor to write the result to. If not provided, a new tensor will be allocated.
     """
 
     def expand_single_value(v: _Any | list[_Any] | None) -> list[_Any]:
@@ -6948,6 +6950,7 @@ def scaled_grouped_mm(
         output_dtype,
         contraction_dim,
         use_fast_accum,
+        out,
     )
 
     return out


### PR DESCRIPTION
## Summary
- Add support for optional `out` argument in `torch.scaled_grouped_mm`, that the caller can use to pass a preallocated output buffer to.

## Tests
- Added test case in `test/test_scaled_matmul_cuda.py`